### PR TITLE
feat: add ansible config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ stow --verbose --target="${HOME}" \
 --dir="${HOME}/.local/share/dotfiles/public" -R */
 ```
 
+## Ansible
+
+These dotfiles include an Ansible control-node configuration under `~/.config/ansible/`.
+
+### Install
+
+```sh
+pipx install ansible-core
+# or
+brew install ansible
+```
+
+After installing, restow the ansible package if needed:
+
+```sh
+stow --target="$HOME" ansible
+```
+
+### Verify
+
+A simple `ping` playbook lives at `~/.config/ansible/playbooks/ping.yml`.
+
+```sh
+ansible-playbook ~/.config/ansible/playbooks/ping.yml
+```
+
+This uses the bundled inventory (`~/.config/ansible/inventory/hosts`) and should return `pong` for `localhost`.
+
 ## zsh
 
 This is my personal zsh configuration.  While I am sure I have pulled from

--- a/ansible/.config/ansible/ansible.cfg
+++ b/ansible/.config/ansible/ansible.cfg
@@ -1,5 +1,7 @@
 [defaults]
-inventory = ~/.config/ansible/inventory
-roles_path = /opt/ansible/roles:~/.cache/ansible/roles
-collections_paths = /opt/ansible/collections:/usr/share/ansible/collections:~/.cache/ansible/colleections
-
+inventory = ~/.config/ansible/inventory/hosts
+roles_path = ~/.ansible/roles
+collections_path = ~/.ansible/collections
+interpreter_python = auto_silent
+retry_files_enabled = False
+host_key_checking = False

--- a/ansible/.config/ansible/inventory/hosts
+++ b/ansible/.config/ansible/inventory/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible/.config/ansible/playbooks/ping.yml
+++ b/ansible/.config/ansible/playbooks/ping.yml
@@ -1,0 +1,8 @@
+---
+- name: Verify Ansible control node
+  hosts: local
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Ping localhost
+      ansible.builtin.ping:


### PR DESCRIPTION
## Summary
- add an `ansible` package that stows into `~/.config/ansible/` with a default `ansible.cfg` and inventory
- include a tiny `playbooks/ping.yml` so we can verify the install
- document how to install ansible (pipx/brew), restow the package, and run the sample playbook

## Testing
- not run (ansible is not installed in this container)
