### PR TITLE
feat(nvim): add project.nvim project picker

### DIFF
--- a/nvim/.config/nvim/lua/plugins/projects.lua
+++ b/nvim/.config/nvim/lua/plugins/projects.lua
@@ -1,0 +1,32 @@
+-- Plugin Spec: Project Management
+-- Adds project root detection + Telescope integration via project.nvim
+return {
+  {
+    "ahmedkhalf/project.nvim",
+    event = "VeryLazy",
+    dependencies = { "nvim-telescope/telescope.nvim" },
+    config = function()
+      local ok, project = pcall(require, "project_nvim")
+      if not ok then
+        return
+      end
+
+      project.setup({
+        manual_mode = false,
+        detection_methods = { "lsp", "pattern" },
+        patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json" },
+        show_hidden = false,
+        silent_chdir = true,
+        scope_chdir = "global",
+      })
+
+      vim.keymap.set("n", "<leader>fp", function()
+        local telescope_ok, telescope = pcall(require, "telescope")
+        if not telescope_ok then
+          return
+        end
+        telescope.extensions.projects.projects({})
+      end, { desc = "Find project" })
+    end,
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/search.lua
+++ b/nvim/.config/nvim/lua/plugins/search.lua
@@ -20,14 +20,16 @@ return {
 	{
 		"nvim-telescope/telescope-ui-select.nvim",
 		config = function()
-			require("telescope").setup({
+			local telescope = require("telescope")
+			telescope.setup({
 				extensions = {
 					["ui-select"] = {
 						require("telescope.themes").get_dropdown({}),
 					},
 				},
 			})
-			require("telescope").load_extension("ui-select")
+			telescope.load_extension("ui-select")
+			pcall(telescope.load_extension, "projects")
 		end,
 	},
 }


### PR DESCRIPTION
## Summary
- add a dedicated `project.nvim` plugin spec with sensible defaults and a `<leader>fp` shortcut for quickly jumping between projects
- load the Telescope `projects` extension alongside the existing `ui-select` config so the picker is wired up automatically

## Testing
- `HOME=/home/cheliped XDG_CONFIG_HOME=$PWD/dotfiles-repo/nvim/.config XDG_DATA_HOME=/home/cheliped/.local/share XDG_STATE_HOME=/home/cheliped/.local/state XDG_CACHE_HOME=/home/cheliped/.cache /home/cheliped/.local/nvim-linux-arm64/bin/nvim --headless "+Lazy! sync" +qa`
- `HOME=/home/cheliped XDG_CONFIG_HOME=$PWD/dotfiles-repo/nvim/.config XDG_DATA_HOME=/home/cheliped/.local/share XDG_STATE_HOME=/home/cheliped/.local/state XDG_CACHE_HOME=/home/cheliped/.cache /home/cheliped/.local/nvim-linux-arm64/bin/nvim --headless "+lua require('telescope').extensions.projects.projects{}" +qa`

## Acceptance Criteria
- [x] `project.nvim` is installed/tested locally
- [x] Evaluation summary captured on the issue
- [x] Configuration committed to the repo
- [ ] Integration stage to merge + verify downstream

## Risk
Low — localized to Neovim plugin configuration. Main rollback lever is reverting the new plugin spec if it causes runtime issues.
