### PR TITLE
docs(nvim): document toggleterm keybindings and configuration

### DIFF
--- a/nvim/.config/nvim/lua/plugins/README.md
+++ b/nvim/.config/nvim/lua/plugins/README.md
@@ -26,7 +26,14 @@ Provides functionality for file management.
 
 ### Terminal(terminal.lua)
 
-Provides pop-up terminal.
+Provides a floating pop-up terminal via `toggleterm.nvim`.
+
+| Mode     | Keys  | Action                       |
+| -------- | ----- | ---------------------------- |
+| Normal   | `<C-t>` | Toggle the floating terminal |
+| Terminal | `<C-t>` | Close the floating terminal  |
+
+**Configuration:** floating window (120 × 35), zsh shell, auto-scroll, starts in insert mode.
 
 ### Artificial Intelligence(ai.lua)
 

--- a/nvim/.config/nvim/lua/plugins/terminal.lua
+++ b/nvim/.config/nvim/lua/plugins/terminal.lua
@@ -1,4 +1,26 @@
- return {
+-- Plugin Spec: Terminal
+--
+-- Provides a floating pop-up terminal inside Neovim.
+--
+-- ## Plug-In
+--
+-- - [toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim)
+--
+-- ## Keybindings
+--
+-- | Mode         | Keys    | Action                        |
+-- | ------------ | ------- | ----------------------------- |
+-- | Normal       | <C-t>   | Toggle the floating terminal  |
+-- | Terminal     | <C-t>   | Toggle (close) the terminal   |
+--
+-- ## Configuration Notes
+--
+-- - Shell: zsh (`/bin/zsh`)
+-- - Direction: float (120×35)
+-- - Auto-scroll: enabled
+-- - Starts in insert mode when opened
+
+return {
    { 
     "akinsho/toggleterm.nvim",
     version = "v2.*",  -- Optionally specify a version


### PR DESCRIPTION
## Summary
Add inline header comment to `terminal.lua` documenting the keybindings, shell, and layout, and expand the Terminal section in `README.md` with a keybindings table and configuration notes.

`toggleterm.nvim` was already installed and functional; this PR closes the documentation gap required by the acceptance criteria.

## Acceptance Criteria
- [x] [Develop] `toggleterm.nvim` is in the Neovim config (pre-existing)
- [x] [Develop] Keybindings documented in plugin spec and README
- [ ] [Integrate] Passes linting and basic checks
- [ ] [Run] Validated in the live environment

## Risk
Low — documentation only, no functional code changes.